### PR TITLE
Add support for waiter RequestLimitExceeded exceptions.

### DIFF
--- a/awsretry/__init__.py
+++ b/awsretry/__init__.py
@@ -106,6 +106,9 @@ class AWSRetry(CloudRetry):
         elif isinstance(error, boto.compat.StandardError):
             return boto.compat.StandardError
 
+        elif isinstance(error, botocore.exceptions.WaiterError):
+            return botocore.exceptions.WaiterError
+
         else:
             return type(None)
 
@@ -113,6 +116,8 @@ class AWSRetry(CloudRetry):
     def status_code_from_exception(error):
         if isinstance(error, botocore.exceptions.ClientError):
             return error.response['Error']['Code']
+        if isinstance(error, botocore.exceptions.WaiterError):
+            return error.last_response['Error']['Code']
         else:
             return error.error_code
 


### PR DESCRIPTION
Our internal cluster provisioning system uses boto3 waiters at various points in the deployment pipeline to wait for instances to enter certain states before proceeding onto the next task.  When stress testing the system we started encountering RequestLimitExceeded for waiters.  It turns out waiters raise a different exception and store the response in `last_response` instead of `response`.  The actual response looks the same though and so is the error code (RequestLimitExceeded). 