### PR TITLE
Use logging rather than syslog

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,12 +107,14 @@ the ``pip install awsretry`` defined above:
 Running Tests
 -------------
 
-You can run the tests by using tox which implements nosetest or run them
-directly using nosetest.
+You can run the tests by using `tox` which implements nosetest:
 
 .. code-block:: sh
 
     $ tox
-    $ tox tests/test_awsretry.py
-    $ tox -e py27,py36 tests/
-    $ nosetest
+
+Alternatively, you can run them directly using `nosetests`:
+
+.. code-block:: sh
+
+    $ nosetests

--- a/awsretry/__init__.py
+++ b/awsretry/__init__.py
@@ -14,8 +14,6 @@ import boto3
 __author__ = 'Allen Sanabria'
 __version__ = '1.0.2'
 
-logging.basicConfig(level=logging.INFO)
-
 class CloudRetry(object):
     """ CloudRetry can be used by any cloud provider, in order to implement a
         backoff algorithm/retry effect based on Status Code from Exceptions.

--- a/awsretry/__init__.py
+++ b/awsretry/__init__.py
@@ -11,6 +11,8 @@ import botocore
 import boto
 import boto3
 
+log = logging.getLogger('awsretry')
+
 __author__ = 'Allen Sanabria'
 __version__ = '1.0.2'
 
@@ -73,7 +75,7 @@ class CloudRetry(object):
                         if isinstance(e, base_exception_class):
                             response_code = cls.status_code_from_exception(e)
                             if cls.found(response_code, added_exceptions):
-                                logging.warning("%s: Retrying in %d seconds..." % (str(e), max_delay))
+                                log.warning("%s: Retrying in %d seconds..." % (str(e), max_delay))
                                 time.sleep(max_delay)
                                 max_tries -= 1
                                 max_delay *= backoff

--- a/awsretry/__init__.py
+++ b/awsretry/__init__.py
@@ -14,6 +14,7 @@ import boto3
 __author__ = 'Allen Sanabria'
 __version__ = '1.0.2'
 
+logging.basicConfig(level=logging.INFO)
 
 class CloudRetry(object):
     """ CloudRetry can be used by any cloud provider, in order to implement a

--- a/awsretry/__init__.py
+++ b/awsretry/__init__.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function
 from __future__ import unicode_literals
 from functools import wraps
 import re
-import syslog
+import logging
 import time
 
 import botocore
@@ -74,11 +74,7 @@ class CloudRetry(object):
                         if isinstance(e, base_exception_class):
                             response_code = cls.status_code_from_exception(e)
                             if cls.found(response_code, added_exceptions):
-                                msg = (
-                                    "{0}: Retrying in {1} seconds..."
-                                    .format(str(e), max_delay)
-                                )
-                                syslog.syslog(syslog.LOG_INFO, msg)
+                                logging.info("%s: Retrying in %d seconds..." % (str(e), max_delay))
                                 time.sleep(max_delay)
                                 max_tries -= 1
                                 max_delay *= backoff

--- a/awsretry/__init__.py
+++ b/awsretry/__init__.py
@@ -75,7 +75,7 @@ class CloudRetry(object):
                         if isinstance(e, base_exception_class):
                             response_code = cls.status_code_from_exception(e)
                             if cls.found(response_code, added_exceptions):
-                                logging.info("%s: Retrying in %d seconds..." % (str(e), max_delay))
+                                logging.warning("%s: Retrying in %d seconds..." % (str(e), max_delay))
                                 time.sleep(max_delay)
                                 max_tries -= 1
                                 max_delay *= backoff

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,3 @@
 boto
 boto3
 botocore
-
-[dev]
-check-manifest
-
-[test]
-coverage
-nose

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
 
     install_requires=['boto', 'boto3', 'botocore'],
     tests_require=['coverage', 'nose', 'tox'],
+    test_suite='nose.collector',
 
     extras_require={
         'dev': ['check-manifest'],

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ setup(
     keywords='boto3 aws retry awsretry backoff',
 
     install_requires=['boto', 'boto3', 'botocore'],
+    tests_require=['coverage', 'nose', 'tox'],
 
     extras_require={
         'dev': ['check-manifest'],
-        'test': ['coverage', 'nose'],
     },
 )


### PR DESCRIPTION
This simply moves away from `syslog` so that this code will more readily work on non-Linux systems.  I tested this locally with one of our problematic bits of boto code (well, it isn't boto that is problematic so much as it is the S3-compatible service we are interfacing with...):

```
2018-03-14 11:08:31,052 root         WARNING    An error occurred (504) when calling the HeadObject operation (reached max retries: 4): Gateway Timeout: Retrying in 3 seconds...
```

I've also fixed a variety of other little things I noticed along the way that hinder development and testing.  Any feedback is much appreciated.

Thanks for looking!