### PR TITLE
Handle case no error_code

### DIFF
--- a/awsretry/__init__.py
+++ b/awsretry/__init__.py
@@ -114,8 +114,9 @@ class AWSRetry(CloudRetry):
             return error.response['Error']['Code']
         if isinstance(error, botocore.exceptions.WaiterError):
             return error.last_response['Error']['Code']
-        else:
+        elif hasattr(error, 'error_code'):
             return error.error_code
+        return error.__class__.__name__
 
     @staticmethod
     def found(response_code, added_exceptions):


### PR DESCRIPTION
Not all errors has the error_code property. e.g case is `botocore.exceptions.EndpointConnectionError` when we connect to a service in a region where it is not rolled out yet.
This caused a runtime exception that may be fixed with this PR.