### PR TITLE
Use loguru if available

### DIFF
--- a/awsretry/__init__.py
+++ b/awsretry/__init__.py
@@ -4,7 +4,10 @@ from __future__ import absolute_import, division, print_function
 from __future__ import unicode_literals
 from functools import wraps
 import re
-import logging
+try:
+    from loguru import logger as logging
+except:
+    import logging
 import time
 
 import botocore


### PR DESCRIPTION
A lot of people like [loguru](https://github.com/Delgan/loguru). 
We can use it if it's available, otherwise revert to regular logging.