### PR TITLE
Add 3 more exceptions

### DIFF
--- a/awsretry/__init__.py
+++ b/awsretry/__init__.py
@@ -123,7 +123,8 @@ class AWSRetry(CloudRetry):
         # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
         retry_on = [
             'RequestLimitExceeded', 'Unavailable', 'ServiceUnavailable',
-            'InternalFailure', 'InternalError'
+            'InternalFailure', 'InternalError', 'LimitExceededException',
+            'TooManyRequestsException', 'ThrottlingException'
         ]
         retry_on.extend(added_exceptions)
 


### PR DESCRIPTION
I use boto3 quite extensively and have found that I need to retry a few more exceptions. I could declare it in the decorator but I think it's fairly undifferentiated, so you can make it available to all of us.

TooManyRequestsException: often thrown by Api Gateway
ThrottlingException: many services incl. CodeDeploy and DynamoDB.
LimitExceededException: by ApiGateway, ACM, etc
